### PR TITLE
Add support for External ID field on Advertisers

### DIFF
--- a/app/controllers/manage/advertiser/edit/index.js
+++ b/app/controllers/manage/advertiser/edit/index.js
@@ -42,7 +42,7 @@ export default Controller.extend(ActionMixin, {
      *
      * @param {object} fields
      */
-    async update({ id, name, website, notify }) {
+    async update({ id, name, website, externalId, notify }) {
       this.startAction();
       const promises = [];
       ['internal', 'external'].forEach((type) => {
@@ -52,7 +52,7 @@ export default Controller.extend(ActionMixin, {
         const mutation = setContacts;
         promises.push(this.get('apollo').mutate({ mutation, variables }, 'setAdvertiserContacts'));
       });
-      const payload = { name, website };
+      const payload = { name, website, externalId };
       const variables = { input: { id, payload } };
       const mutation = updateAdvertiser;
 

--- a/app/gql/fragments/advertiser/edit.graphql
+++ b/app/gql/fragments/advertiser/edit.graphql
@@ -4,6 +4,7 @@
 fragment AdvertiserEditFragment on Advertiser {
   id
   name
+  externalId
   website
   hash
   logo {

--- a/app/gql/fragments/advertiser/list.graphql
+++ b/app/gql/fragments/advertiser/list.graphql
@@ -5,6 +5,7 @@
 fragment AdvertiserListFragment on Advertiser {
   id
   name
+  externalId
   updatedAt
   createdAt
   ...TimestampableFragment

--- a/app/templates/manage/advertiser/form.hbs
+++ b/app/templates/manage/advertiser/form.hbs
@@ -36,6 +36,23 @@
       </div>
     </div>
   </div>
+  <div class="col">
+    <div class="form-group">
+      <label for="externalId">External ID</label>
+      {{input
+        type="text"
+        autocomplete="off"
+        value=form.model.externalId
+        class="form-control"
+        id="externalId"
+        focusOut=(action form.actions.autosave)
+        keyUp=(action form.actions.autosave 750)
+      }}
+      <div class="invalid-feedback">
+        Please provide a valid external ID.
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="row">

--- a/app/templates/manage/advertiser/list-item.hbs
+++ b/app/templates/manage/advertiser/list-item.hbs
@@ -16,6 +16,7 @@
           <p class="mb-0">Campaigns: {{if item.campaigns.totalCount item.campaigns.totalCount 0}}</p>
           <p class="mb-1">Stories: {{if item.stories.totalCount item.stories.totalCount 0}}</p>
           <small>ID: {{item.id}}</small>
+          {{#if item.externalId}}<small>External ID: {{item.externalId}}</small>{{/if}}
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fortnight",
-  "version": "1.1.7",
+  "version": "1.3.0",
   "private": true,
   "description": "Small description for fortnight goes here",
   "license": "MIT",


### PR DESCRIPTION
Requires parameter1/fortnight-graph#1

Advertiser edit
![screencapture-localhost-8105-app-advertiser-5f690184e73980001282d0a9-2020-09-21-15_22_55](https://user-images.githubusercontent.com/1778222/93818072-809a4100-fc1f-11ea-8d81-b934a7c510d0.png)

Advertiser list
![screencapture-localhost-8105-app-advertiser-2020-09-21-15_24_09](https://user-images.githubusercontent.com/1778222/93818069-7f691400-fc1f-11ea-9146-6a2d0ddc63f2.png)