### PR TITLE
Add front-end support for unique exclusions

### DIFF
--- a/app/gql/fragments/placement/view.graphql
+++ b/app/gql/fragments/placement/view.graphql
@@ -3,6 +3,8 @@ fragment PlacementFragment on Placement {
   name
   updatedAt
   reservePct
+  uniqueAdvertisers
+  uniqueCampaigns
   publisher {
     id
     name

--- a/app/services/placement-manager.js
+++ b/app/services/placement-manager.js
@@ -71,6 +71,8 @@ export default Service.extend(ObjectQueryManager, {
     template,
     topic,
     reservePct,
+    uniqueAdvertisers,
+    uniqueCampaigns,
   } = {}) {
     return {
       name,
@@ -78,6 +80,8 @@ export default Service.extend(ObjectQueryManager, {
       templateId: get(template || {}, 'id'),
       topicId: get(topic || {}, 'id'),
       reservePct: reservePct || 0,
+      uniqueAdvertisers,
+      uniqueCampaigns,
     };
   },
 });

--- a/app/templates/manage/placement/form.hbs
+++ b/app/templates/manage/placement/form.hbs
@@ -37,7 +37,7 @@
 <div class="row">
 
   <div class="col-sm-6 col-md-9 col-lg-10">
-    <div class="form-group mb-3 mb-sm-0">
+    <div class="form-group">
       <label for="placement-name">Label</label>
       {{input
         type="text"
@@ -52,7 +52,7 @@
   </div>
 
   <div class="col-sm-6 col-md-3 col-lg-2">
-    <div class="form-group mb-0">
+    <div class="form-group">
       <label for="placement-reserve-pct">Impression Reserve</label>
 
       <div class="input-group">
@@ -76,4 +76,43 @@
     </div>
   </div>
 
+</div>
+
+<div class="row">
+  <div class="col">
+    <strong>Exclusions</strong>
+    <hr class="mt-0">
+  </div>
+</div>
+<div class="row">
+
+  <div class="col-sm-6">
+    <div class="form-group mb-3 mb-sm-0">
+      <label for="placement-unique-advertisers">Same Advertiser</label>
+      {{input
+        type="checkbox"
+        checked=form.model.uniqueAdvertisers
+        class="form-control"
+        id="placement-unique-advertisers"
+        focusIn=(action form.actions.autosave 250)
+        keyUp=(action form.actions.autosave 250)
+      }}
+      <small class="form-text text-muted">When checked, this placement will not return the same advertiser more than once per request.</small>
+    </div>
+  </div>
+
+  <div class="col-sm-6">
+    <div class="form-group mb-3 mb-sm-0">
+      <label for="placement-unique-campaigns">Same Campaign</label>
+      {{input
+        type="checkbox"
+        checked=form.model.uniqueCampaigns
+        class="form-control"
+        id="placement-unique-campaigns"
+        focusIn=(action form.actions.autosave 250)
+        keyUp=(action form.actions.autosave 250)
+      }}
+      <small class="form-text text-muted">When checked, this placement will not return the same campaign more than once per request.</small>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
- [ ] Requires (pending pr)

Adds front-end support for the two new exclusion fields on placements: Advertiser & Campaign. This will become mergeable once the back-end support in GraphQL is complete.

![screencapture-localhost-8105-app-placement-5f4ff650940a650001095e1a-2020-09-29-13_43_15](https://user-images.githubusercontent.com/1778222/94602182-266e3100-025a-11eb-930d-acb14ba73902.png)
![screencapture-localhost-8105-app-placement-5f4ff650940a650001095e1a-2020-09-29-13_42_45](https://user-images.githubusercontent.com/1778222/94602186-279f5e00-025a-11eb-82e2-7ede53e87bc4.png)
![screencapture-localhost-8105-app-placement-5f4ff650940a650001095e1a-2020-09-29-13_42_27](https://user-images.githubusercontent.com/1778222/94602188-2837f480-025a-11eb-8c9a-845363b2c55b.png)
