### PR TITLE
Add `linkText` to campaign creatives

### DIFF
--- a/app/controllers/manage/campaign/edit/creatives/create.js
+++ b/app/controllers/manage/campaign/edit/creatives/create.js
@@ -46,13 +46,24 @@ export default Controller.extend(ActionMixin, {
      *
      * @param {object} fields
      */
-    async create({ title, teaser, image }) {
+    async create({
+      title,
+      teaser,
+      linkText,
+      image
+    } = {}) {
       this.startAction();
       const active = true;
       const campaignId = this.get('campaignId');
       const imageId = get(image, 'id');
 
-      const payload = { title, teaser, active, imageId };
+      const payload = {
+        title,
+        teaser,
+        linkText,
+        active,
+        imageId,
+      };
       const variables = { input: { campaignId, payload } };
       const refetchQueries = ['CampaignCreatives'];
       try {

--- a/app/controllers/manage/campaign/edit/creatives/edit.js
+++ b/app/controllers/manage/campaign/edit/creatives/edit.js
@@ -56,12 +56,22 @@ export default Controller.extend(ActionMixin, {
      *
      * @param {object} fields
      */
-    async updateDetails({ title, teaser, active }) {
+    async updateDetails({
+      title,
+      teaser,
+      linkText,
+      active,
+    } = {}) {
       this.startAction();
 
       const creativeId = this.get('model.id');
       const campaignId = this.get('campaignId');
-      const payload = { title, teaser, active };
+      const payload = {
+        title,
+        teaser,
+        linkText,
+        active,
+      };
 
       const mutation = campaignCreativeDetails;
       const input = { creativeId, campaignId, payload }

--- a/app/controllers/portal/campaigns/manage/materials/creatives/create.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/create.js
@@ -45,13 +45,24 @@ export default Controller.extend(ActionMixin, {
      *
      * @param {object} fields
      */
-    async create({ title, teaser, image }) {
+    async create({
+      title,
+      teaser,
+      linkText,
+      image
+    } = {}) {
       this.startAction();
       const active = true;
       const campaignId = this.get('campaign.id');
       const imageId = get(image, 'id');
 
-      const payload = { title, teaser, active, imageId };
+      const payload = {
+        title,
+        teaser,
+        linkText,
+        active,
+        imageId,
+      };
       const variables = { input: { campaignId, payload } };
       const refetchQueries = ['PortalCampaignsManageMaterials'];
 

--- a/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
+++ b/app/controllers/portal/campaigns/manage/materials/creatives/edit.js
@@ -58,11 +58,21 @@ export default Controller.extend(ActionMixin, {
      *
      * @param {object} fields
      */
-    async updateDetails({ id, title, teaser }) {
+    async updateDetails({
+      id,
+      title,
+      linkText,
+      teaser
+    } = {}) {
       this.startAction();
 
       const campaignId = this.get('campaign.id');
-      const payload = { title, teaser, active: true };
+      const payload = {
+        title,
+        teaser,
+        linkText,
+        active: true,
+      };
 
       const mutation = campaignCreativeDetails;
       const input = { creativeId: id, campaignId, payload }

--- a/app/gql/fragments/campaign-creative/details.graphql
+++ b/app/gql/fragments/campaign-creative/details.graphql
@@ -2,5 +2,6 @@ fragment CampaignCreativeDetailsFragment on CampaignCreative {
   id
   title
   teaser
+  linkText
   active
 }

--- a/app/templates/components/campaign-creative.hbs
+++ b/app/templates/components/campaign-creative.hbs
@@ -20,6 +20,10 @@
     <p class="card-text">{{teaser}}</p>
   {{/if}}
 
+  {{#if linkText}}
+    <p class="card-text"><span class="text-muted">Link Text:</span> {{linkText}}</p>
+  {{/if}}
+
 </div>
 <div class="card-footer d-flex justify-content-between">
   {{#if displayEditButton}}

--- a/app/templates/components/campaign-creative/preview-grid.hbs
+++ b/app/templates/components/campaign-creative/preview-grid.hbs
@@ -5,6 +5,9 @@
 {{#if creative.teaser}}
 <p>{{ creative.teaser }}</p>
 {{/if}}
+{{#if creative.linkText}}
+<p><button class="btn btn-primary" type="button">{{ creative.linkText }}</button></p>
+{{/if}}
 {{#if campaign.criteria.start}}
   <p class="mb-0">
     <strong>Sponsored</strong> - {{moment-format campaign.criteria.start "MMM DD, YYYY"}}

--- a/app/templates/components/campaign-creative/preview-list.hbs
+++ b/app/templates/components/campaign-creative/preview-list.hbs
@@ -4,6 +4,9 @@
   </div>
   <div class="col-7">
     <h5 class="font-weight-bold">{{ creative.title }}</h5>
+    {{#if creative.linkText}}
+      <p><button class="btn btn-sm btn-primary" type="button">{{ creative.linkText }}</button></p>
+    {{/if}}
     <p><strong>Sponsored</strong> - {{moment-format campaign.criteria.start "MMM DD, YYYY"}}</p>
   </div>
 </div>

--- a/app/templates/manage/campaign/edit/creatives.hbs
+++ b/app/templates/manage/campaign/edit/creatives.hbs
@@ -9,6 +9,7 @@
           campaignId=model.id
           title=creative.title
           teaser=creative.teaser
+          linkText=creative.linkText
           active=creative.active
           image=creative.image
         }}

--- a/app/templates/manage/campaign/forms/creative.hbs
+++ b/app/templates/manage/campaign/forms/creative.hbs
@@ -26,7 +26,7 @@
 
 <div class="row">
   <div class="col">
-    <div class="form-group mb-0">
+    <div class="form-group">
       <label for="creative-teaser">Teaser {{required-field-label}}</label>
       {{character-count value=form.model.teaser maxLength=255}}
       {{textarea
@@ -46,6 +46,30 @@
       </div>
       <small id={{concat "teaserHelp." index}} class="form-text text-muted">
         A short description for your link. This must be at least 40 characters long and no longer than 255.
+      </small>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col">
+    <div class="form-group mb-0">
+      <label for="creative-link-text">Link Text</label>
+      {{character-count value=form.model.linkText maxLength=32}}
+      {{input
+        id="creative-link-text"
+        class="form-control"
+        maxlength=32
+        required=false
+        value=form.model.linkText
+        focusOut=(action form.actions.autosave)
+        keyUp=(action form.actions.autosave 750)
+      }}
+      <div class="invalid-feedback">
+        Please provide link text that is no longer than 32 characters.
+      </div>
+      <small id={{concat "link-textHelp." index}} class="form-text text-muted">
+        Call to action text. This is <em>only</em> used in email campaigns.
       </small>
     </div>
   </div>

--- a/app/templates/portal/campaigns/manage/materials.hbs
+++ b/app/templates/portal/campaigns/manage/materials.hbs
@@ -38,6 +38,7 @@
                   campaignId=model.id
                   title=creative.title
                   teaser=creative.teaser
+                  linkText=creative.linkText
                   active=creative.active
                   image=creative.image
                 }}


### PR DESCRIPTION
Campaign creative edit/create:
![image](https://user-images.githubusercontent.com/3289485/116263220-cf243680-a73e-11eb-86c5-88ba45913812.png)

Material collect list:
![image](https://user-images.githubusercontent.com/3289485/116263305-e2cf9d00-a73e-11eb-836a-eaf90100ef5c.png)

Material collect "preview"
![image](https://user-images.githubusercontent.com/3289485/116263350-ea8f4180-a73e-11eb-8125-353dbd176723.png)

Creative breakdown report:
![image](https://user-images.githubusercontent.com/3289485/116263399-f4b14000-a73e-11eb-91a3-3e31dc6e7fe7.png)

Ref parameter1/fortnight-graph#10
